### PR TITLE
The chkcrontab script doesn't exit with the proper error code

### DIFF
--- a/chkcrontab
+++ b/chkcrontab
@@ -40,4 +40,4 @@ def main(argv):
   return check.check_crontab(argv[1], log)
 
 if __name__ == '__main__':
-  main(sys.argv)
+  sys.exit(main(sys.argv))


### PR DESCRIPTION
What steps will reproduce the problem?
1. run chkcrontab on an erroneous crontab file
2. echo $?

The script should exit with the status 2, instead it exists with the status 0.

This pull requests fixes this issue.
