### PR TITLE
allow debian helper

### DIFF
--- a/chkcrontab_lib.py
+++ b/chkcrontab_lib.py
@@ -84,7 +84,7 @@ USER_WHITELIST = set(('postgres', 'buildbot',
 # The following extensions imply further postprocessing or that the slack
 # role was for a cron that allowed dots in cron scripts.
 FILE_RE_WHITELIST = [re.compile(x) for x in
-                     ('\.in$', '\.cron$', '\.disabled$')]
+                     (r'\.in$', r'\.cron$', r'\.disabled$', r'^(\S+\.)?cron\.d$')]
 
 
 class FSM(object):


### PR DESCRIPTION
I use  chkcrontab to check crontab files from debian source packages. 
Debian build system itself copies files with proper name to the proper location.
Crontab source files name inside deb package source is  debian/cron.d or debian/pkg-name.cron.d
Can you add them as a correct crontab names?
