### PR TITLE
Check command regardless of the USER_WHITELIST

### DIFF
--- a/chkcrontab_lib.py
+++ b/chkcrontab_lib.py
@@ -707,7 +707,7 @@ class CronLineTimeAction(object):
 
     # User checks.
     if self.user in USER_WHITELIST:
-      return
+      pass
     elif len(self.user) > 31:
       log.LineError(log.MSG_INVALID_USER,
                     'Username too long "%s"' % self.user)

--- a/tests/test_crontab.whitelist
+++ b/tests/test_crontab.whitelist
@@ -1,3 +1,5 @@
 # WARN 1 for questionable file name.
 # WARN 0 for missing user
 1 * * * * not_a_user Command
+# WARN 1 for missing user and questionable bare %
+1 * * * * not_a_user Command with %


### PR DESCRIPTION
Command checks does not work when the user in `USER_WHITELIST`.
